### PR TITLE
Support 'url' from node and msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Pulled together using some of the best of parts of other node-red-contrib nodes 
 Currently only sends files. However, there are future plans to handle other types multipart/form-data.
 
 ## Usage
-Required inputs: url (this is specified on the node) & filepath (path to the file to be sent)
-Filepath can be indicated 2 ways:
-1. Explicitly state the filepath on the node (useful if filepath is a constant)
-2. Pass the filepath into the node as part of the msg, as "msg.filepath"
+Required inputs: url & filepath
+
+Both can be indicated 2 ways:
+1. Explicitly state the input on the node (e.g. filepath and/or url is a constant)
+2. Pass the inputs into the node as part of the msg, as "msg.filepath" or "msg.url"
 
 
 ## Why this module?

--- a/http-send-multipart.html
+++ b/http-send-multipart.html
@@ -14,6 +14,11 @@
 	</div>
 
 	<div class="form-row">
+		<label for="node-input-filename"> Filename </label>
+		<input type="text" id="node-input-filename" placeholder="alternative filename">
+	</div>
+
+	<div class="form-row">
 		<input type="checkbox" id="node-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
 		<label for="node-input-usetls" style="width: auto">  Enable secure (SSL/TLS) connection </label>
 		<div id="node-row-tls" class="hide">
@@ -52,7 +57,8 @@
 		<li><code>url</code>, if set, is used as the url of the request. Must start with <em>http:</em> or <em>https:</em>. If left blank, the node will load the info from the <code>msg</code> object at <code>msg.url</code>.</li>
 		<li><code>headers</code>, if set, should be an object containing field/value pairs to be added as request headers</li>
 		<li><code>payload</code> is sent as the body of the request</li>
-    <li><code>filepath</code>, if set, will load the file from the given path, relative to the location of the NodeRed project.  If left blank, the node will load the info from the <code>msg</code> object at <code>msg.filepath</code>. When both fail, the flow will fail with a warning.</li>
+		<li><code>filepath</code>, if set, will load the file from the given path, relative to the location of the NodeRed project.  If left blank, the node will load the info from the <code>msg</code> object at <code>msg.filepath</code>. When both fail, the flow will fail with a warning.</li>
+		<li><code>filename</code>, if set, will use the value as name of the file for the upload.  If left blank, the node will use the value of <code>filename</code></li>
 	</ul>
 	<p>When configured within the node, the URL property can contain <a href="http://mustache.github.io/mustache.5.html" target="_new">mustache-style</a> tags. These allow the url to be constructed using values of the incoming message. For example, if the url
 		is set to

--- a/http-send-multipart.html
+++ b/http-send-multipart.html
@@ -50,10 +50,10 @@
 	<p>Provides a node for posting multipart form-data.</p>
 	<p>The URL must be configured in the node.</p>
 	<ul>
-		<li><code>url</code>, if set, is used as the url of the request. Must start with http: or https:</li>
+		<li><code>url</code>, if set, is used as the url of the request. Must start with <em>http:</em> or <em>https:</em>. If left blank, the node will load the info from the <code>msg</code> object at <code>msg.url</code>.</li>
 		<li><code>headers</code>, if set, should be an object containing field/value pairs to be added as request headers</li>
 		<li><code>payload</code> is sent as the body of the request</li>
-    <li><code>filepath</code>, if set, will load the file from the given path, relative to the location of the NodeRed project.  If left blank, the node will look for the file in the root directory of the NodeRed project.</li>
+    <li><code>filepath</code>, if set, will load the file from the given path, relative to the location of the NodeRed project.  If left blank, the node will load the info from the <code>msg</code> object at <code>msg.filepath</code>. When both fail, the flow will fail with a warning.</li>
 	</ul>
 	<p>When configured within the node, the URL property can contain <a href="http://mustache.github.io/mustache.5.html" target="_new">mustache-style</a> tags. These allow the url to be constructed using values of the incoming message. For example, if the url
 		is set to

--- a/http-send-multipart.html
+++ b/http-send-multipart.html
@@ -48,7 +48,6 @@
 
 <script type="text/x-red" data-help-name="http-send-multipart">
 	<p>Provides a node for posting multipart form-data.</p>
-	<p>The URL must be configured in the node.</p>
 	<ul>
 		<li><code>url</code>, if set, is used as the url of the request. Must start with <em>http:</em> or <em>https:</em>. If left blank, the node will load the info from the <code>msg</code> object at <code>msg.url</code>.</li>
 		<li><code>headers</code>, if set, should be an object containing field/value pairs to be added as request headers</li>

--- a/http-send-multipart.js
+++ b/http-send-multipart.js
@@ -95,9 +95,16 @@ module.exports = function(RED) {
                     'Content-Type': 'multipart/form-data'
                 };
                 if (msg.headers) {
-                    var headers = extend({}, headers, msg.headers);
+                    headers = extend({}, headers, msg.headers);
                 }
                 msg['request-headers'] = headers;
+
+                var fName = filepath;
+                if(n.filename) {
+                    fName = n.filename;
+                } else if (!msg.filename) {
+                    fName = msg.filename;
+                }
 
                 var options = {
                     method: 'POST',
@@ -107,7 +114,7 @@ module.exports = function(RED) {
                         file: {
                             value: fs.createReadStream(filepath),
                             options: {
-                                filename: filepath,
+                                filename: fName,
                                 contentType: null
                             }
                         },

--- a/http-send-multipart.js
+++ b/http-send-multipart.js
@@ -11,9 +11,6 @@ module.exports = function(RED) {
         // Setup node
         RED.nodes.createNode(this, n);
         var node = this;
-        var nodeUrl = n.url;
-
-        var isTemplatedUrl = (nodeUrl || "").indexOf("{{") != -1;
 
         this.ret = n.ret || "txt"; // default return type is text
         if (RED.settings.httpRequestTimeout) {
@@ -24,6 +21,13 @@ module.exports = function(RED) {
 
         // 1) Process inputs to Node
         this.on("input", function(msg) {
+
+			// Load 'url' parameter from node and try msg as failover
+	        var nodeUrl = n.url;
+			if(!nodeUrl) {
+				nodeUrl = msg.url;
+			}
+			var isTemplatedUrl = (nodeUrl || "").indexOf("{{") != -1;
 
             // Object extend
             function extend(target) {

--- a/http-send-multipart.js
+++ b/http-send-multipart.js
@@ -136,8 +136,8 @@ module.exports = function(RED) {
                     }
                     msg.payload = body;
                     msg.statusCode = resp.statusCode || resp.status;
-                    msg.['http-send-multipart-headers'] = resp.headers;
-                    msg.['http-send-multipart-options'] = options;
+                    msg.headers = resp.headers;
+                    msg.options = options;
 
                     if (node.ret !== "bin") {
                         msg.payload = body.toString('utf8'); // txt


### PR DESCRIPTION
The node will now also accept the 'url' parameter from the msg in addition to the node settings. This way we are not dependant on the URL being static.